### PR TITLE
ENH handle mapping not in ARO in map_to_aro function & simplify map_to_aro() code

### DIFF
--- a/argnorm/lib.py
+++ b/argnorm/lib.py
@@ -50,6 +50,8 @@ def map_to_aro(gene, database):
 
     Returns:
         ARO[result] (pronto.term.Term): A pronto term with the ARO number of input gene. ARO number can be accessed using 'id' attribute and gene name can be accessed using 'name' attribute.
+
+        If ARO mapping is invalid or doesn't exist, an empty list [] is returned.
     """
 
     if database not in ['ncbi', 'deeparg', 'resfinder', 'sarg', 'megares', 'argannot']:
@@ -68,4 +70,3 @@ def map_to_aro(gene, database):
             return ARO[result]
         else:
             return []
-            raise Warning('The gene does not have an ARO mapping')

--- a/argnorm/lib.py
+++ b/argnorm/lib.py
@@ -69,4 +69,4 @@ def map_to_aro(gene, database):
         if result in ARO:
             return ARO[result]
         else:
-            return []
+            return None

--- a/argnorm/lib.py
+++ b/argnorm/lib.py
@@ -51,7 +51,7 @@ def map_to_aro(gene, database):
     Returns:
         ARO[result] (pronto.term.Term): A pronto term with the ARO number of input gene. ARO number can be accessed using 'id' attribute and gene name can be accessed using 'name' attribute.
 
-        If ARO mapping is invalid or doesn't exist, None is returned.
+        If ARO mapping is doesn't exist, None is returned.
     """
 
     if database not in ['ncbi', 'deeparg', 'resfinder', 'sarg', 'megares', 'argannot']:
@@ -64,9 +64,8 @@ def map_to_aro(gene, database):
     except KeyError:
         raise Exception(f'{gene} is not in {database} database')
     else:
-        ARO = pronto.Ontology.from_obo_library('aro.obo')
-
-        if result in ARO:
-            return ARO[result]
-        else:
+        if pd.isna(result):
             return None
+
+        ARO = pronto.Ontology.from_obo_library('aro.obo')
+        return ARO.get(result)

--- a/argnorm/lib.py
+++ b/argnorm/lib.py
@@ -62,10 +62,10 @@ def map_to_aro(gene, database):
     except KeyError:
         raise Exception(f'{gene} is not in {database} database')
     else:
-        # Dealing with duplicated genes in ARO mapping table.
-        # Getting only one ARO number
         ARO = pronto.Ontology.from_obo_library('aro.obo')
-        if type(result) != str:
-            return ARO[list(set(result))[0]]
-        else:
+
+        if result in ARO:
             return ARO[result]
+        else:
+            return []
+            raise Warning('The gene does not have an ARO mapping')

--- a/argnorm/lib.py
+++ b/argnorm/lib.py
@@ -51,7 +51,7 @@ def map_to_aro(gene, database):
     Returns:
         ARO[result] (pronto.term.Term): A pronto term with the ARO number of input gene. ARO number can be accessed using 'id' attribute and gene name can be accessed using 'name' attribute.
 
-        If ARO mapping is invalid or doesn't exist, an empty list [] is returned.
+        If ARO mapping is invalid or doesn't exist, None is returned.
     """
 
     if database not in ['ncbi', 'deeparg', 'resfinder', 'sarg', 'megares', 'argannot']:

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -7,7 +7,8 @@ def test_map_to_aro():
         ["(AGly)AAC(6')-Isa:NG_047311:101-574:474", 'argannot'],
         ["MEG_21|Drugs|Aminoglycosides|Aminoglycoside_N-acetyltransferases|AAC3", 'megares'],
         ["1028085756|WP_063844287.1|1|1|cpt|cpt|phosphotransferase|2|CHLORAMPHENICOL|PHENICOL|chloramphenicol_phosphotransferase_CPT", 'ncbi'],
-        ["gb|AAG57600.1|ARO:3000318|mphB", "sarg"]
+        ["gb|AAG57600.1|ARO:3000318|mphB", "sarg"],
+        ["(Phe)cpt_strepv:U09991:AAB36569:1412-1948:537", "argannot"]
     ]
 
     ARO = pronto.Ontology.from_obo_library('aro.obo')
@@ -15,7 +16,8 @@ def test_map_to_aro():
         ARO.get_term('ARO:3002563'),
         ARO.get_term('ARO:3004623'),
         ARO.get_term('ARO:3000249'),
-        ARO.get_term('ARO:3000318')
+        ARO.get_term('ARO:3000318'),
+        []
     ]
 
     for t, e in zip(test_cases, expected_output):

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -17,7 +17,7 @@ def test_map_to_aro():
         ARO.get_term('ARO:3004623'),
         ARO.get_term('ARO:3000249'),
         ARO.get_term('ARO:3000318'),
-        []
+        None
     ]
 
     for t, e in zip(test_cases, expected_output):


### PR DESCRIPTION
- Currently there is no way to handle a 'nan' mapping being passed to 'ARO[result]' in the map_to_aro function. This means that when a gene which does not have an ARO mapping is passed into map_to_aro(), an error is thrown as 'nan' is not in the ARO.

- The previous map_to_aro code also dealt with multiple ARO mappings which is not an issue anymore since gene clusters, reverse complements and CDSs being dealt as cotings have been solved for all databases (except megares which is currently being looked into).