### PR TITLE
ENH specific version for NCBI in db_harmonisation & clean up harmonisation code

### DIFF
--- a/db_harmonisation/construct_megares_mapping.py
+++ b/db_harmonisation/construct_megares_mapping.py
@@ -161,16 +161,11 @@ def merge_megares_mappings(cds_mapping, contig_mapping):
     cds_mapping = pd.read_csv(cds_mapping, sep='\t')
     contig_mapping = pd.read_csv(contig_mapping, sep='\t')
 
-    print(cds_mapping)
-    print(contig_mapping)
-
     cds_mapping['Original ID'] = cds_mapping['ORF_ID']
     contig_mapping['Original ID'] = contig_mapping['Contig'].apply(lambda x: '_'.join(x.split('_')[:-1]))
 
     cds_mapping = cds_mapping[['Original ID', 'ARO']]
     contig_mapping = contig_mapping[['Original ID', 'ARO']]
-
-    print(megares_mappings)
 
     megares_mappings.set_index('Original ID').drop(index=set(cds_mapping['Original ID']) & set(megares_mappings.index), inplace=True)
     megares_mappings.set_index('Original ID').drop(index=set(contig_mapping['Original ID']) & set(megares_mappings.index), inplace=True)

--- a/db_harmonisation/crude_db_harmonisation.py
+++ b/db_harmonisation/crude_db_harmonisation.py
@@ -28,7 +28,7 @@ def get_resfinderfg_db():
 
 def get_ncbi_db():
     ofile = 'dbs/ncbi_amr_raw.faa'
-    url = 'https://ftp.ncbi.nlm.nih.gov/pathogen/Antimicrobial_resistance/AMRFinderPlus/database/latest/AMRProt'
+    url = 'https://ftp.ncbi.nlm.nih.gov/pathogen/Antimicrobial_resistance/AMRFinderPlus/database/3.12/2024-01-31.1/AMRProt'
     return download_file(url, ofile)
 
 def get_resfinder_db():
@@ -54,10 +54,6 @@ def get_deeparg_db():
 def get_argannot_db():
     url = 'https://www.mediterranee-infection.com/wp-content/uploads/2019/06/ARG_ANNOT_V5_AA_JUNE2019.txt'
     return download_file(url, 'dbs/argannot.faa')
-
-def get_megares_db():
-    url = 'https://www.meglab.org/downloads/megares_v3.00/megares_database_v3.00.fasta'
-    return download_file(url, 'dbs/megares.fna')
 
 # NCBI db has '*' at end of each protein sequence. RGI can't handle that, so '*' is removed
 @TaskGenerator
@@ -128,7 +124,6 @@ for db in [
         get_sarg_db(),
         get_resfinderfg_db(),
         get_deeparg_db(),
-        get_megares_db(),
         get_argannot_db()
     ]:
     move_mappings_to_argnorm(run_rgi(db))


### PR DESCRIPTION
- Remove unnecessary print statements in construct_megares_mappings
- Remove unnecessary get_megares_db function in crude_db_harmonisation
- Change NCBI version to 3.12 in crude_db_harmonisation from 'latest'