### PR TITLE
BUG manually curate misannotated gene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Manual curation
+- argannot_curation: (Tet)tetH:EF460464:6286-7839:1554 was incorrectly annotated as ARO:3004797 which is a beta-lactamase due to a loose RGI hit. This was manually curated to ARO:3000175.
+
 ## 0.4.0 - 10 June
 
 - Bundle a specific version of ARO with the package instead of downloading it from the internet (ensures reproducibility)

--- a/argnorm/data/manual_curation/argannot_curation.tsv
+++ b/argnorm/data/manual_curation/argannot_curation.tsv
@@ -1,2 +1,3 @@
 Original ID	ARO	Gene Name in CARD	Description
 (Phe)cpt_strepv:U09991:AAB36569:1412-1948:537	3000249	chloramphenicol phosphotransferase	Parent ARO mapping
+(Tet)tetH:EF460464:6286-7839:1554	3000175	tet(H)	Loose RGI mapping. Mapped incorrectly to ARO:3004797.

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -2,10 +2,10 @@ import pytest
 from argnorm import lib
 from argnorm import drug_categorization
 
+ARO = lib.get_aro_ontology()
+
 @pytest.mark.parametrize('database', lib.DATABASES)
 def test_database(database):
-    ARO = lib.get_aro_ontology()
-
     determinant_of_ab_resistance = ARO['ARO:3000000']
     antibiotic_molecule = ARO['ARO:1000003']
     assert determinant_of_ab_resistance.name == 'determinant of antibiotic resistance'
@@ -23,3 +23,5 @@ def test_database(database):
                 assert dc in ARO, f'ARO not found in the ontology: {dc}'
                 assert antibiotic_molecule in  ARO[dc].superclasses(1), f'ARO term not an immediate child of antibiotic molecule: {dc}'
 
+def test_misannotated_genes():
+    assert lib.map_to_aro('(Tet)tetH:EF460464:6286-7839:1554', 'argannot') == ARO['ARO:3000175']


### PR DESCRIPTION
(Tet)tetH:EF460464:6286-7839:1554 was incorrectly annotated as ARO:3004797 which is a beta-lactamase due to a loose RGI hit. This was manually curated to ARO:3000175.