### PR TITLE
Updated manual curation for misannotated genes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Manual curation
 - argannot_curation: (Tet)tetH:EF460464:6286-7839:1554 was incorrectly annotated as ARO:3004797 which is a beta-lactamase due to a loose RGI hit. This was manually curated to ARO:3000175.
+- deeparg, megares, resfinderfg & sarg curation: ARO:3004445 -> ARO:3005440, this was due to a change in the ARO and the ARO number for the RSA2 gene changing. **db_harmonisation must change to take this into account**
+> Incorrectly curated genes. Previously, they were directly mapped to drug classes. Correct parent ARO term has now been given.
+> - resfinder_curation: grdA_1_QJX10702 -> 3007380 & EstDL136_1_JN242251 -> 3000557
+> - megares_curation: MEG_2865|Drugs|Phenicol|Chloramphenicol_hydrolase|ESTD -> 3000557
 
 ## 0.4.0 - 10 June
 

--- a/argnorm/data/manual_curation/deeparg_curation.tsv
+++ b/argnorm/data/manual_curation/deeparg_curation.tsv
@@ -1,13 +1,14 @@
 Original ID	ARO	Gene Name in CARD	Description
-CP000034.1.gene2198.p01|FEATURES|ompF|multidrug|ompF	3000265	porin OmpF	
-AAB08925|FEATURES|tetU|tetracycline|tetU	3004650	tet(U)	
-CP000647.1.gene2517.p01|FEATURES|ompF|multidrug|ompF	3000265	porin OmpF	
-gi:504720116:ref:WP_014907218.1:|FEATURES|ompF|multidrug|ompF	3000265	porin OmpF	
-AM180355.1.gene2260.p01|FEATURES|ermC|MLS|ermC	3000250	ErmC	
-gi:501976562:ref:WP_012681429.1:|FEATURES|cystathionine_beta-lyase_patB|unclassified|cystathionine_beta-lyase_patB	3000025	patB	
+CP000034.1.gene2198.p01|FEATURES|ompF|multidrug|ompF	3000265	porin OmpF
+AAB08925|FEATURES|tetU|tetracycline|tetU	3004650	tet(U)
+CP000647.1.gene2517.p01|FEATURES|ompF|multidrug|ompF	3000265	porin OmpF
+gi:504720116:ref:WP_014907218.1:|FEATURES|ompF|multidrug|ompF	3000265	porin OmpF
+AM180355.1.gene2260.p01|FEATURES|ermC|MLS|ermC	3000250	ErmC
+gi:501976562:ref:WP_012681429.1:|FEATURES|cystathionine_beta-lyase_patB|unclassified|cystathionine_beta-lyase_patB	3000025	patB
 gi:447201629:ref:WP_001278885.1:|FEATURES|cob(I)alamin_adenolsyltransferase|unclassified|cob(I)alamin_adenolsyltransferase	0010004	RND type drug efflux	https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2696896/
-gi:489831097:ref:WP_003734834.1:|FEATURES|cystathionine_beta-lyase_patB|unclassified|cystathionine_beta-lyase_patB	3000025	patB	
-gi:685904080:ref:WP_031644138.1:|FEATURES|cystathionine_beta-lyase_patB|unclassified|cystathionine_beta-lyase_patB	3000025	patB	
-NP_253005.1|FEATURES|MvaT|multidrug|MvaT	3004069	MvaT	
-NP_417544.5|FEATURES|patA|fluoroquinolone|patA	3000024	patA	
-NP_416340.1|FEATURES|mgrB|multidrug|mgrB	3003820	mgrB	
+gi:489831097:ref:WP_003734834.1:|FEATURES|cystathionine_beta-lyase_patB|unclassified|cystathionine_beta-lyase_patB	3000025	patB
+gi:685904080:ref:WP_031644138.1:|FEATURES|cystathionine_beta-lyase_patB|unclassified|cystathionine_beta-lyase_patB	3000025	patB
+NP_253005.1|FEATURES|MvaT|multidrug|MvaT	3004069	MvaT
+NP_417544.5|FEATURES|patA|fluoroquinolone|patA	3000024	patA
+NP_416340.1|FEATURES|mgrB|multidrug|mgrB	3003820	mgrB
+AUW34359.1|FEATURES|RSA-2|beta-lactam|RSA-2	3005440	RSA2 beta-lactamase	ARO number of RSA2 had been changed.

--- a/argnorm/data/manual_curation/megares_curation.tsv
+++ b/argnorm/data/manual_curation/megares_curation.tsv
@@ -1,88 +1,89 @@
 Original ID	ARO	Description
-MEG_8443|Drugs|Pleuromutilin|Pleuromutilin-resistant_23S_rRNA_mutation|P23S|RequiresSNPConfirmation	3005083	
+MEG_8443|Drugs|Pleuromutilin|Pleuromutilin-resistant_23S_rRNA_mutation|P23S|RequiresSNPConfirmation	3005083
 MEG_4060|Metals|Multi-metal_resistance|Multi-metal_resistance_protein|MREA		Metal resistance. No mapping
-MEG_2865|Drugs|Phenicol|Chloramphenicol_hydrolase|ESTD	3000387	
-MEG_1732|Drugs|Lipopeptides|Daptomycin-resistant_mutant|CLS|RequiresSNPConfirmation	3003092	
-MEG_2933|Drugs|Mycobacterium_tuberculosis-specific_Drug|Para-aminosalicylic_acid_resistant_mutant|FOLC|RequiresSNPConfirmation	3004157	
+MEG_2865|Drugs|Phenicol|Chloramphenicol_hydrolase|ESTD	3000557
+MEG_1732|Drugs|Lipopeptides|Daptomycin-resistant_mutant|CLS|RequiresSNPConfirmation	3003092
+MEG_2933|Drugs|Mycobacterium_tuberculosis-specific_Drug|Para-aminosalicylic_acid_resistant_mutant|FOLC|RequiresSNPConfirmation	3004157
 MEG_8700|Multi-compound|Biocide_and_metal_resistance|Biocide_and_metal_ABC_efflux_pumps|SITABCD		Metal + Biocide resistance. No mapping
-MEG_8447|Drugs|Fluoroquinolones|Fluoroquinolone-resistant_DNA_topoisomerases|PARC|RequiresSNPConfirmation	3000274	
-MEG_6241|Drugs|betalactams|Class_A_betalactamases|SHV	3001059	
-MEG_7974|Drugs|betalactams|Class_C_betalactamase_regulator|AMPCR|RequiresSNPConfirmation	3000076	
-MEG_3987|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004546	
-MEG_6055|Drugs|Mycobacterium_tuberculosis-specific_Drug|Para-aminosalicylic_acid_resistant_mutant|RIBD|RequiresSNPConfirmation	3004184	
-MEG_6144|Drugs|Aminoglycosides|Aminoglycoside-resistant_16S_ribosomal_subunit_protein|RPSL|RequiresSNPConfirmation	3003395	
+MEG_8447|Drugs|Fluoroquinolones|Fluoroquinolone-resistant_DNA_topoisomerases|PARC|RequiresSNPConfirmation	3000274
+MEG_6241|Drugs|betalactams|Class_A_betalactamases|SHV	3001059
+MEG_7974|Drugs|betalactams|Class_C_betalactamase_regulator|AMPCR|RequiresSNPConfirmation	3000076
+MEG_3987|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004546
+MEG_6055|Drugs|Mycobacterium_tuberculosis-specific_Drug|Para-aminosalicylic_acid_resistant_mutant|RIBD|RequiresSNPConfirmation	3004184
+MEG_6144|Drugs|Aminoglycosides|Aminoglycoside-resistant_16S_ribosomal_subunit_protein|RPSL|RequiresSNPConfirmation	3003395
 MEG_3745|Multi-compound|Drug_and_biocide_and_metal_resistance|Drug_and_biocide_and_metal_RND_efflux_pumps|MDTA		Metal + Biocide resistance. No mapping
-MEG_8140|Drugs|Aminoglycosides|Gentamicin-resistant_ATP-binding_protein|GRDA	3003949	
-MEG_5285|Drugs|betalactams|Class_A_betalactamases|OXY	3002390	
+MEG_8140|Drugs|Aminoglycosides|Gentamicin-resistant_ATP-binding_protein|GRDA	3003949
+MEG_5285|Drugs|betalactams|Class_A_betalactamases|OXY	3002390
 MEG_8643|Multi-compound|Drug_and_biocide_resistance|Drug_and_biocide_MFS_efflux_pumps|QACAB		Biocide resistance. No mapping
 MEG_8644|Multi-compound|Drug_and_biocide_resistance|Drug_and_biocide_MFS_efflux_pumps|QACAB		Biocide resistance. No mapping
-MEG_3071|Drugs|Fusidic_acid|Fusidic_acid-resistant_mutation|FUSE|RequiresSNPConfirmation	3003737	
-MEG_3986|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004174	
+MEG_3071|Drugs|Fusidic_acid|Fusidic_acid-resistant_mutation|FUSE|RequiresSNPConfirmation	3003737
+MEG_3986|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004174
 MEG_2062|Metals|Copper_resistance|Copper_resistance_protein|COPL		Metal resistance. No mapping
 MEG_8646|Multi-compound|Drug_and_biocide_resistance|Drug_and_biocide_SMR_efflux_pumps|QACD		Biocide resistance. No mapping
-MEG_6137|Drugs|Lipopeptides|Daptomycin-resistant_beta-subunit_of_RNA_polymerase_RpoB|RPOBL|RequiresSNPConfirmation	3003287	
-MEG_6136|Drugs|Lipopeptides|Daptomycin-resistant_beta-subunit_of_RNA_polymerase_RpoB|RPOBL|RequiresSNPConfirmation	3003285	
+MEG_6137|Drugs|Lipopeptides|Daptomycin-resistant_beta-subunit_of_RNA_polymerase_RpoB|RPOBL|RequiresSNPConfirmation	3003287
+MEG_6136|Drugs|Lipopeptides|Daptomycin-resistant_beta-subunit_of_RNA_polymerase_RpoB|RPOBL|RequiresSNPConfirmation	3003285
 MEG_1180|Drugs|Multi-drug_resistance|Multi-drug_RND_efflux_regulator|ASMA		Muti-drug resistance. No mapping
 MEG_1179|Drugs|Multi-drug_resistance|Multi-drug_RND_efflux_regulator|ASMA		Muti-drug resistance. No mapping
 MEG_8642|Multi-compound|Drug_and_biocide_resistance|Drug_and_biocide_MFS_efflux_pumps|QACAB		Biocide resistance. No mapping
-MEG_497|Drugs|betalactams|Class_C_betalactamases|ACT	3000072	
+MEG_497|Drugs|betalactams|Class_C_betalactamases|ACT	3000072
 MEG_8087|Biocides|Aldehyde_resistance|Aldehyde_degradation|FORMA		Biocide resistance. No mapping
-MEG_2114|Drugs|Phenicol|Chloramphenicol_phosphotransferase|CPT	3000249	
+MEG_2114|Drugs|Phenicol|Chloramphenicol_phosphotransferase|CPT	3000249
 MEG_8651|Multi-compound|Drug_and_biocide_resistance|Drug_and_biocide_SMR_efflux_pumps|QACL		Biocide resistance. No mapping
-MEG_5337|Drugs|Fluoroquinolones|Fluoroquinolone-resistant_DNA_topoisomerases|PARC|RequiresSNPConfirmation	3000274	
-MEG_7344|Drugs|Glycopeptides|VanA-type_resistance_protein|VANA	3000010	
-MEG_5780|Drugs|Lipopeptides|Daptomycin-resistant_mutant|PGSA|RequiresSNPConfirmation	3003323	
+MEG_5337|Drugs|Fluoroquinolones|Fluoroquinolone-resistant_DNA_topoisomerases|PARC|RequiresSNPConfirmation	3000274
+MEG_7344|Drugs|Glycopeptides|VanA-type_resistance_protein|VANA	3000010
+MEG_5780|Drugs|Lipopeptides|Daptomycin-resistant_mutant|PGSA|RequiresSNPConfirmation	3003323
 MEG_8647|Multi-compound|Drug_and_biocide_resistance|Drug_and_biocide_SMR_efflux_pumps|QACF		Biocide resistance. No mapping
-MEG_4033|Drugs|MLS|Macrolide_phosphotransferases|MPHB	3000318	
+MEG_4033|Drugs|MLS|Macrolide_phosphotransferases|MPHB	3000318
 MEG_8645|Multi-compound|Drug_and_biocide_resistance|Drug_and_biocide_SMR_efflux_pumps|QACC		Biocide resistance. No mapping
-MEG_3980|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004165	
-MEG_1|Drugs|Aminoglycosides|Aminoglycoside-resistant_16S_ribosomal_subunit_protein|A16S|RequiresSNPConfirmation	3003485	
-MEG_6963|Drugs|Tetracyclines|Tetracycline-resistant_16S_ribosomal_subunit_protein|TET16S|RequiresSNPConfirmation	3003510	
-MEG_3588|Drugs|Lipopeptides|Daptomycin-resistant_mutant|LIAFSR|RequiresSNPConfirmation	3003077	
-MEG_5781|Drugs|Phenicol|Phenicol-resistant_23S_rRNA_mutation|PH23S|RequiresSNPConfirmation	3004180	
+MEG_3980|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004165
+MEG_1|Drugs|Aminoglycosides|Aminoglycoside-resistant_16S_ribosomal_subunit_protein|A16S|RequiresSNPConfirmation	3003485
+MEG_6963|Drugs|Tetracyclines|Tetracycline-resistant_16S_ribosomal_subunit_protein|TET16S|RequiresSNPConfirmation	3003510
+MEG_3588|Drugs|Lipopeptides|Daptomycin-resistant_mutant|LIAFSR|RequiresSNPConfirmation	3003077
+MEG_5781|Drugs|Phenicol|Phenicol-resistant_23S_rRNA_mutation|PH23S|RequiresSNPConfirmation	3004180
 MEG_3857|Metals|Mercury_resistance|Mercury_resistance_protein|MERC		Metal resistance. No mapping
-MEG_3982|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004163	
-MEG_2430|Drugs|betalactams|Class_A_betalactamases|CTX	3000016	
+MEG_3982|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004163
+MEG_2430|Drugs|betalactams|Class_A_betalactamases|CTX	3000016
 MEG_8648|Multi-compound|Drug_and_biocide_resistance|Drug_and_biocide_SMR_efflux_pumps|QACG		Biocide resistance. No mapping
 MEG_8650|Multi-compound|Drug_and_biocide_resistance|Drug_and_biocide_SMR_efflux_pumps|QACH		Biocide resistance. No mapping
-MEG_3445|Drugs|Mycobacterium_tuberculosis-specific_Drug|Isoniazid-resistant_mutant|KASA|RequiresSNPConfirmation	3003463	
-MEG_7259|Drugs|Aminoglycosides|Aminoglycoside-resistant_arabinosyltransferase|TLYA|RequiresSNPConfirmation	3003465	
-MEG_1983|Drugs|betalactams|Class_C_betalactamases|CMY	3002095	
-MEG_7075|Drugs|Tetracyclines|Tetracycline_resistance_MFS_efflux_pumps|TETE	3000173	
-MEG_3983|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004177	
-MEG_6147|Drugs|Aminoglycosides|Aminoglycoside-resistant_16S_ribosomal_subunit_protein|RRSH|RequiresSNPConfirmation	3003372	
-MEG_8254|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004836	
-MEG_6493|Drugs|betalactams|Class_A_betalactamases|SHV	3001139	
-MEG_3993|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004168	
-MEG_1319|Drugs|betalactams|Class_A_betalactamases|BLASME	3002379	
-MEG_5208|Drugs|betalactams|Class_D_betalactamases|OXA	3001410	
-MEG_2414|Drugs|betalactams|Class_A_betalactamases|CTX	3001904	
-MEG_2421|Drugs|betalactams|Class_A_betalactamases|CTX	3001927	
-MEG_3976|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004134	
-MEG_6875|Drugs|betalactams|Class_A_betalactamases|TEM	3000884	
-MEG_3989|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004179	
-MEG_6964|Drugs|Tetracyclines|Tetracycline-resistant_16S_ribosomal_subunit_protein|TET16S|RequiresSNPConfirmation	3003499	
-MEG_2|Drugs|Aminoglycosides|Aminoglycoside-resistant_16S_ribosomal_subunit_protein|A16S|RequiresSNPConfirmation	3003512	
-MEG_3975|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004169	
-MEG_2423|Drugs|betalactams|Class_A_betalactamases|CTX	3001932	
+MEG_3445|Drugs|Mycobacterium_tuberculosis-specific_Drug|Isoniazid-resistant_mutant|KASA|RequiresSNPConfirmation	3003463
+MEG_7259|Drugs|Aminoglycosides|Aminoglycoside-resistant_arabinosyltransferase|TLYA|RequiresSNPConfirmation	3003465
+MEG_1983|Drugs|betalactams|Class_C_betalactamases|CMY	3002095
+MEG_7075|Drugs|Tetracyclines|Tetracycline_resistance_MFS_efflux_pumps|TETE	3000173
+MEG_3983|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004177
+MEG_6147|Drugs|Aminoglycosides|Aminoglycoside-resistant_16S_ribosomal_subunit_protein|RRSH|RequiresSNPConfirmation	3003372
+MEG_8254|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004836
+MEG_6493|Drugs|betalactams|Class_A_betalactamases|SHV	3001139
+MEG_3993|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004168
+MEG_1319|Drugs|betalactams|Class_A_betalactamases|BLASME	3002379
+MEG_5208|Drugs|betalactams|Class_D_betalactamases|OXA	3001410
+MEG_2414|Drugs|betalactams|Class_A_betalactamases|CTX	3001904
+MEG_2421|Drugs|betalactams|Class_A_betalactamases|CTX	3001927
+MEG_3976|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004134
+MEG_6875|Drugs|betalactams|Class_A_betalactamases|TEM	3000884
+MEG_3989|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004179
+MEG_6964|Drugs|Tetracyclines|Tetracycline-resistant_16S_ribosomal_subunit_protein|TET16S|RequiresSNPConfirmation	3003499
+MEG_2|Drugs|Aminoglycosides|Aminoglycoside-resistant_16S_ribosomal_subunit_protein|A16S|RequiresSNPConfirmation	3003512
+MEG_3975|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004169
+MEG_2423|Drugs|betalactams|Class_A_betalactamases|CTX	3001932
 MEG_8263|Multi-compound|Drug_and_biocide_resistance|Drug_and_biocide_RND_efflux_pumps|MTRC|RequiresSNPConfirmation		Biocide resistance. No mapping
-MEG_985|Drugs|Aminoglycosides|Aminoglycoside_O-nucleotidyltransferases|ANT4-PRIME	3000229	
-MEG_3979|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004176	
-MEG_3990|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004171	
-MEG_2425|Drugs|betalactams|Class_A_betalactamases|CTX	3002002	
-MEG_3129|Drugs|betalactams|Class_A_betalactamases|GES	3002337	
-MEG_3131|Drugs|betalactams|Class_A_betalactamases|GES	3002350	
-MEG_6146|Drugs|Aminoglycosides|Aminoglycoside-resistant_16S_ribosomal_subunit_protein|RRSC|RequiresSNPConfirmation	3003333	
-MEG_3393|Drugs|betalactams|Class_B_betalactamases|IMP	3002223	
-MEG_3991|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004133	
-MEG_8679|Drugs|Oxazolidinone|Oxazolidinone-resistant_23S_rRNA_mutation|RRL|RequiresSNPConfirmation	3004937	
-MEG_2427|Drugs|betalactams|Class_A_betalactamases|CTX	3001982	
-MEG_1490|Drugs|Cationic_antimicrobial_peptides|Cationic_peptide-resistant_16S_ribosomal_subunit_protein|CAP16S|RequiresSNPConfirmation	3003223	
-MEG_2393|Drugs|betalactams|Class_A_betalactamases|CTX	3001960	
-MEG_333|Drugs|Aminoglycosides|Aminoglycoside_N-acetyltransferases|AAC6-PRIME	3002578	
-MEG_3396|Drugs|betalactams|Class_B_betalactamases|IMP	3002205	
-MEG_1544|Drugs|betalactams|Class_A_betalactamases|CARB	3002243	
-MEG_2429|Drugs|betalactams|Class_A_betalactamases|CTX	3001943	
-MEG_5148|Drugs|betalactams|Class_D_betalactamases|OXA	3001555	
-MEG_7604|Drugs|Glycopeptides|VanD-type_accessory_protein|VANYD	3002957	
-MEG_8253|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004836	
+MEG_985|Drugs|Aminoglycosides|Aminoglycoside_O-nucleotidyltransferases|ANT4-PRIME	3000229
+MEG_3979|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004176
+MEG_3990|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004171
+MEG_2425|Drugs|betalactams|Class_A_betalactamases|CTX	3002002
+MEG_3129|Drugs|betalactams|Class_A_betalactamases|GES	3002337
+MEG_3131|Drugs|betalactams|Class_A_betalactamases|GES	3002350
+MEG_6146|Drugs|Aminoglycosides|Aminoglycoside-resistant_16S_ribosomal_subunit_protein|RRSC|RequiresSNPConfirmation	3003333
+MEG_3393|Drugs|betalactams|Class_B_betalactamases|IMP	3002223
+MEG_3991|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004133
+MEG_8679|Drugs|Oxazolidinone|Oxazolidinone-resistant_23S_rRNA_mutation|RRL|RequiresSNPConfirmation	3004937
+MEG_2427|Drugs|betalactams|Class_A_betalactamases|CTX	3001982
+MEG_1490|Drugs|Cationic_antimicrobial_peptides|Cationic_peptide-resistant_16S_ribosomal_subunit_protein|CAP16S|RequiresSNPConfirmation	3003223
+MEG_2393|Drugs|betalactams|Class_A_betalactamases|CTX	3001960
+MEG_333|Drugs|Aminoglycosides|Aminoglycoside_N-acetyltransferases|AAC6-PRIME	3002578
+MEG_3396|Drugs|betalactams|Class_B_betalactamases|IMP	3002205
+MEG_1544|Drugs|betalactams|Class_A_betalactamases|CARB	3002243
+MEG_2429|Drugs|betalactams|Class_A_betalactamases|CTX	3001943
+MEG_5148|Drugs|betalactams|Class_D_betalactamases|OXA	3001555
+MEG_7604|Drugs|Glycopeptides|VanD-type_accessory_protein|VANYD	3002957
+MEG_8253|Drugs|MLS|Macrolide-resistant_23S_rRNA_mutation|MLS23S|RequiresSNPConfirmation	3004836
+MEG_6148|Drugs|betalactams|Class_A_betalactamases|RSA	3005440	ARO number of RSA2 had been changed.

--- a/argnorm/data/manual_curation/resfinder_curation.tsv
+++ b/argnorm/data/manual_curation/resfinder_curation.tsv
@@ -9,7 +9,7 @@ VanC2XY_1_EU151754	glycopeptide resistance gene cluster VanC	3000246	https://www
 VanHAX_PT_1_DQ018710	glycopeptide resistance gene cluster VanA	3000236	https://www.ncbi.nlm.nih.gov/nuccore/DQ018710.1	5109-7715	Part of VanA cluster (ARO:3000236)
 VanHAX_PA_1_DQ018711	glycopeptide resistance gene cluster VanA	3000236	https://www.ncbi.nlm.nih.gov/nuccore/DQ018711.1?report=fasta	3168-5750	Part of VanA cluster (ARO:3000236)
 VanHAX_PT_2_AY926880	glycopeptide resistance gene cluster VanA	3000236	https://www.ncbi.nlm.nih.gov/nuccore/AY926880.2?report=fasta	2771-5377	Part of VanA cluster (ARO:3000236)
-dldHA2X_1_AL939117	D-Ala-D-Ala ligase	3003970	https://www.ncbi.nlm.nih.gov/nuccore/AL939117.1	53343-56013	
+dldHA2X_1_AL939117	D-Ala-D-Ala ligase	3003970	https://www.ncbi.nlm.nih.gov/nuccore/AL939117.1	53343-56013
 VanHBX_1_AF192329	glycopeptide resistance gene cluster VanB	3000238	https://www.ncbi.nlm.nih.gov/nuccore/AF192329	27871-30477	Part of VanB cluster (ARO:3000238)
 VanHBX_2_U35369	glycopeptide resistance gene cluster VanB	3000238	https://www.ncbi.nlm.nih.gov/nuccore/U35369.1?report=fasta	4007-6613	"Part of VanB cluster (ARO:3000238). Contains ARO:3002943, ARO:3002950"
 VanC4XY_1_EU151752	glycopeptide resistance gene cluster VanC	3000246	https://www.ncbi.nlm.nih.gov/nuccore/EU151752.1?report=fasta	29-1650	Part of VanC cluster (ARO:3000246)
@@ -43,8 +43,8 @@ blaBKC-1_1_KP689347	BKC-1	3004757			Reverse complement in resfinder db.
 mph(A)_1_D16251	mphA	3000316			Reverse complement in resfinder db.
 qepA1_1_AB263754	QepA2	3004103			Reverse complement in resfinder db.
 tet(43)_1_GQ244501	tet(43)	3000573			Reverse complement in resfinder db.
-blaSPG-1_1_KP109680	SPG-1	3003720			
-blaBIM-1_1_CP016446	BlaB	3004201			
-grdA_1_QJX10702		3007382			Parent ARO mapping
-aac(3)-I_1_AJ877225	AAC(3)-I	3007384			
-EstDL136_1_JN242251		3000387			Parent ARO mapping
+blaSPG-1_1_KP109680	SPG-1	3003720
+blaBIM-1_1_CP016446	BlaB	3004201
+grdA_1_QJX10702		3007380			Parent ARO mapping
+aac(3)-I_1_AJ877225	AAC(3)-I	3007384
+EstDL136_1_JN242251		3000557			Parent ARO mapping

--- a/argnorm/data/manual_curation/resfinderfg_curation.tsv
+++ b/argnorm/data/manual_curation/resfinderfg_curation.tsv
@@ -1,2 +1,4 @@
-Original ID	ARO	Gene Name in CARD
-UDP-N-acetylmuramoyl-tripeptide--D-alanyl-D-alanine ligase|KF629588.1|pediatric_fecal_sample|CYC	3003970	D-Ala-D-Ala ligase
+Original ID	ARO	Gene Name in CARD	Description
+UDP-N-acetylmuramoyl-tripeptide--D-alanyl-D-alanine ligase|KF629588.1|pediatric_fecal_sample|CYC	3003970	D-Ala-D-Ala ligase	
+Beta-lactamase OXA-1|KU544700.1|sewage|CAZ	3005440	RSA2 beta-lactamase	ARO number of RSA2 had been changed.
+Beta-lactamase OXA-1|MG739504.1|river|AMP	3005440	RSA2 beta-lactamase	ARO number of RSA2 had been changed.

--- a/argnorm/data/manual_curation/sarg_curation.tsv
+++ b/argnorm/data/manual_curation/sarg_curation.tsv
@@ -1,3 +1,4 @@
-Original ID	ARO	Gene Name in CARD
-gb|AAG57600.1|ARO:3000318|mphB	3000318	mphB
-AM180355.1.gene2260.p01	3000250	ErmC
+Original ID	ARO	Gene Name in CARD	Description
+gb|AAG57600.1|ARO:3000318|mphB	3000318	mphB	
+AM180355.1.gene2260.p01	3000250	ErmC	
+gb|AUW34359.1|ARO:3004445|RSA-2	3005440	RSA2 beta-lactamase	ARO number of RSA2 had been changed.


### PR DESCRIPTION
- RSA2 was mapped to ARO:3004445. This mapping was changed in the ARO to ARO:3005440. db_harmonisation should pick this up, but temporarily the issue is resolved through manual curation.
- grdA_1_QJX10702 (in resfinder curation) & EstD (in resfinder & megares curation) were mapped directly to drug classes. They are now mapped to correct parent AROs. grdA_1_QJX10702 -> ARO:3007380 and EstD -> ARO:3000557