### PR TITLE
DOC add documentation on output formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+#### argNorm version in outputs from CLI
+The version of argNorm used for normalization is now added to the top of argNorm tsv outputs when generated using the CLI.  For example, 
+
+~~~
+# argNorm version: 0.6.0
+input_sequence_id	input_file_name	gene_symbol	gene_name	reference_database_id ...
+. REST OF ARG ANNOTATION OUTPUT TSV TABLE
+.
+.
+~~~
+
+> **NOTE: This is only if argNorm is used on the CLI, if you used argNorm's normalizers there will be no comment with the argNorm version**
+ 
+> **NOTE: THIS WILL BREAK ANY PREVIOUS SCRIPTS ANALYZING ARGNORM CLI OUTPUTS BEFORE THIS UPDATE! PLEASE USE THE `skiprows=1` ARGUMENT WHEN LOADING ARGNORM OUTPUT DATAFRAMES TO IGNORE THE COMMENT WITH THE ARGNORM VERSION AS SHOWN BELOW:**
+> ```
+> import pandas as pd
+> df = pd.read_csv(<PATH TO ARGNORM OUTPUT>, sep='\t', skiprows=1)
+> ```
+
 ## 0.6.0 - 21 August 2024
 
 #### GROOT support

--- a/README.md
+++ b/README.md
@@ -130,6 +130,16 @@ Here is a basic outline of calling argNorm.
 argnorm [tool] -i [original_annotation.tsv] -o [annotation_result_with_aro.tsv]
 ```
 
+## Outputs
+The following columns are added to the tsv outputs of ARG annotation tools:
+| Table column                 | Description                                                                      |
+| ---------------------------- | -------------------------------------------------------------------------------- |
+| `ARO`                        | ARO accessions of ARG                                                            |
+| `confers_resistance_to`      | ARO accessions of drugs to which ARGs confer resistance to                       |
+| `resistance_to_drug_classes` | ARO accessions of drugs classes to which drugs in `confers_resistance_to` belong |
+
+A comment is added to the very top of the ARG annotation tool outputs specifying the argNorm version used. For example: '# argNorm version: 0.6.0'
+
 ## Example 1: argNorm as a command line tool
 
 Here is a quick demo of running argNorm on the command line.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,24 @@ The following columns are added to the tsv outputs of ARG annotation tools:
 | `confers_resistance_to`      | ARO accessions of drugs to which ARGs confer resistance to                       |
 | `resistance_to_drug_classes` | ARO accessions of drugs classes to which drugs in `confers_resistance_to` belong |
 
-A comment is added to the very top of the ARG annotation tool outputs specifying the argNorm version used. For example: '# argNorm version: 0.6.0'
+A comment is added to the very top of the ARG annotation tool outputs specifying the argNorm version used if ran on the command line. For example:
+
+~~~
+# argNorm version: 0.6.0
+input_sequence_id	input_file_name	gene_symbol	gene_name	reference_database_id ...
+. REST OF ARG ANNOTATION OUTPUT TSV TABLE
+.
+.
+~~~
+
+> **NOTE: This is only if argNorm is used on the CLI, if you used argNorm's normalizers there will be no comment with the argNorm version**
+ 
+> **NOTE: THIS WILL BREAK ANY PREVIOUS SCRIPTS ANALYZING ARGNORM CLI OUTPUTS BEFORE THIS UPDATE! PLEASE USE THE `skiprows=1` ARGUMENT WHEN LOADING ARGNORM OUTPUT DATAFRAMES TO IGNORE THE COMMENT WITH THE ARGNORM VERSION AS SHOWN BELOW:**
+> ```
+> import pandas as pd
+> df = pd.read_csv(<PATH TO ARGNORM OUTPUT>, sep='\t', skiprows=1)
+> ```
+
 
 ## Example 1: argNorm as a command line tool
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,7 +137,24 @@ The following columns are added to the tsv outputs of ARG annotation tools:
 | `confers_resistance_to`      | ARO accessions of drugs to which ARGs confer resistance to                       |
 | `resistance_to_drug_classes` | ARO accessions of drugs classes to which drugs in `confers_resistance_to` belong |
 
-A comment is added to the very top of the ARG annotation tool outputs specifying the argNorm version used. For example: '# argNorm version: 0.6.0'
+A comment is added to the very top of the ARG annotation tool outputs specifying the argNorm version used if ran on the command line. For example:
+
+~~~
+# argNorm version: 0.6.0
+input_sequence_id	input_file_name	gene_symbol	gene_name	reference_database_id ...
+. REST OF ARG ANNOTATION OUTPUT TSV TABLE
+.
+.
+~~~
+
+> **NOTE: This is only if argNorm is used on the CLI, if you used argNorm's normalizers there will be no comment with the argNorm version**
+ 
+> **NOTE: THIS WILL BREAK ANY PREVIOUS SCRIPTS ANALYZING ARGNORM CLI OUTPUTS BEFORE THIS UPDATE! PLEASE USE THE `skiprows=1` ARGUMENT WHEN LOADING ARGNORM OUTPUT DATAFRAMES TO IGNORE THE COMMENT WITH THE ARGNORM VERSION AS SHOWN BELOW:**
+> ```
+> import pandas as pd
+> df = pd.read_csv(<PATH TO ARGNORM OUTPUT>, sep='\t', skiprows=1)
+> ```
+
 
 ## Example 1: argNorm as a command line tool
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -129,6 +129,16 @@ Here is a basic outline of calling argNorm.
 argnorm [tool] -i [original_annotation.tsv] -o [annotation_result_with_aro.tsv]
 ```
 
+## Outputs
+The following columns are added to the tsv outputs of ARG annotation tools:
+| Table column                 | Description                                                                      |
+| ---------------------------- | -------------------------------------------------------------------------------- |
+| `ARO`                        | ARO accessions of ARG                                                            |
+| `confers_resistance_to`      | ARO accessions of drugs to which ARGs confer resistance to                       |
+| `resistance_to_drug_classes` | ARO accessions of drugs classes to which drugs in `confers_resistance_to` belong |
+
+A comment is added to the very top of the ARG annotation tool outputs specifying the argNorm version used. For example: '# argNorm version: 0.6.0'
+
 ## Example 1: argNorm as a command line tool
 
 Here is a quick demo of running argNorm on the command line.


### PR DESCRIPTION
Added a table to the documentation detailing the columns that argNorm adds to ARG annotation tools' outputs. Also mentioned how argNorm displays the software version used in the output tsv files.