### PR TITLE
DOC make it clear that argNorm only support hAMRonized results derived from outputs of supported ARG annotation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ If you use argNorm in a publication, please cite the preprint:
 
 - Note: ARG database and ARG annotation tool versions can change. argNorm is only intended for supported versions listed above.
 - Note: the argNorm tool will be periodically updated to support the latest versions of databases and annotation tools if they undergo significant changes.
+> hAMRonization: argNorm does not support ALL hAMRonized results. **argNorm only supports hAMRonization outputs that were obtained by passing the outputs of the supported ARG annotation tools listed above into hAMRonization**
 
 ## Installation
 argNorm can be installed using pip:

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,7 @@ If you use argNorm in a publication, please cite the preprint:
 
 - Note: ARG database and ARG annotation tool versions can change. argNorm is only intended for supported versions listed above.
 - Note: the argNorm tool will be periodically updated to support the latest versions of databases and annotation tools if they undergo significant changes.
+> hAMRonization: argNorm does not support ALL hAMRonized results. **argNorm only supports hAMRonization outputs that were obtained by passing the outputs of the supported ARG annotation tools listed above into hAMRonization**
 
 ## Installation
 argNorm can be installed using pip:


### PR DESCRIPTION
Response to reviewer 1's 6th comment:

> It is currently not clear / not possible to use hamronized output from a tool that is not under the supported tools listed in the documentation (i.e. ARIBA, which is supported by hamronizer but not argNorm). Potentially this could be addressed if point # 3 is addressed, where outputs from multiple databases cannot be assessed at once. However, authors should make it clear how they selected which tools they support, and acknowledge in the manuscript that argNorm can then only be used for outputs from certain tools and not all hamronized outputs (as tool is a required parameter). 
