### PR TITLE
ADD better error messages if CLI inputs aren't provided correctly

### DIFF
--- a/argnorm/cli.py
+++ b/argnorm/cli.py
@@ -29,8 +29,16 @@ def main():
                         help='The file to save normalization results')
     args = parser.parse_args()
 
+    if args.output is None:
+        sys.stderr.write('Please specify an output file using `-o` or `--output`\n')
+        sys.exit(2)
+
     if args.hamronized:
         sys.stderr.write('Upgrade to use hamronization as a tool instead of a flag\n')
+        sys.exit(2)
+
+    if args.tool in ['groot', 'abricate'] and args.db == None:
+        sys.stderr.write('Please specify a database using `--db` when using groot or abricate\n')
         sys.exit(2)
 
     # We only import the normalize function when the user actually wants to run the program


### PR DESCRIPTION
1) If -o or --output not metioned, prompts user to provide output file path 2) If `groot` or `abricate` tools used without databases, prompts users to provide database 3) If `amrfinderplus` is used without tool version, prompts user to provide tool version