### PR TITLE
Remove duplicates in hamronization's mapping table

### DIFF
--- a/argnorm/normalizers.py
+++ b/argnorm/normalizers.py
@@ -329,7 +329,9 @@ class HamronizationNormalizer(BaseNormalizer):
                 table.index = table.index.str.split('|').str[1]
 
             mapping_tables.append(table)
-
-        return pd.concat(mapping_tables)
+        
+        mapping_table = pd.concat(mapping_tables)
+        mapping_table = mapping_table[~mapping_table.index.duplicated(keep='last')]
+        return mapping_table
 
 


### PR DESCRIPTION
Duplicates are normally removed when creating mapping tables for all databases, however this step was missing for the hamronization mapping table and hence it was added.

It is difficult to use a unique identifier, such as a reference accession, for hamronization as raw outputs use protein ids (e.g. WP_009247026.1) while hamronized outputs use RefSeq ids (e.g. NG_052371.1) which aren't included in the mapping tables. Hence, to avoid adding more complexity (e.g. switching between protein and refseq ids by using Entrez in biopython and storing the refseq ids too), I chose to simply remove duplicates in the hamronization mapping table.